### PR TITLE
Add caching to avoid repeating calculation during translated builds

### DIFF
--- a/sdg/ProgressMeasure.py
+++ b/sdg/ProgressMeasure.py
@@ -1,13 +1,14 @@
 from sdg import Loggable
 
 class IndicatorProgress(Loggable):
-    def __init__(self, indicator, logging=None):
+    def __init__(self, indicator, logging=None, cache_store=None):
 
         Loggable.__init__(self, logging=logging)
         self.indicator = indicator
         self.inid = indicator.inid
         self.data = indicator.data
         self.meta = indicator.meta
+        self.cache_store = cache_store
         # self.indicator_options = indicator.options
 
         # self.auto_progress_calculation = self.meta.get('auto_progress_calculation') is True
@@ -50,6 +51,9 @@ class IndicatorProgress(Loggable):
         """
         # Check if progress calculation is turned on
         if self.meta.get('auto_progress_calculation') is True:
+            # First try to use caching.
+            if self.cache_store is not None and self.inid in self.cache_store:
+                return self.cache_store[self.inid]
             # Get the progress measure score and status for each series/unit/disaggregation specified in the progress calculation options.
             progress_outputs = []
             for config in self.get_progress_calculation_options():
@@ -61,8 +65,10 @@ class IndicatorProgress(Loggable):
                     progress_outputs.append((score, pm.status))
 
             if progress_outputs:
-                # Return a tuple of the minimum score and associated progress status
-                return min(progress_outputs, key=lambda x: x[0])
+                # Cache/return a tuple of the minimum score and associated progress status
+                results = min(progress_outputs, key=lambda x: x[0])
+                self.cache_store[self.inid] = results
+                return results
         else:
             # Use any progress status available in the metadata as a manual override
             if 'progress_status' in self.meta.keys():

--- a/sdg/open_sdg.py
+++ b/sdg/open_sdg.py
@@ -362,6 +362,7 @@ def open_sdg_prep(options):
         logging=options['logging'],
         indicator_export_filename=options['indicator_export_filename'],
         ignore_out_of_scope_disaggregation_stats=options['ignore_out_of_scope_disaggregation_stats'],
+        cache_store = {},
     )
 
     if callable(options['alter_indicator']):

--- a/sdg/outputs/OutputOpenSdg.py
+++ b/sdg/outputs/OutputOpenSdg.py
@@ -12,7 +12,7 @@ class OutputOpenSdg(OutputBase):
     def __init__(self, inputs, schema, output_folder='_site', translations=None,
         reporting_status_extra_fields=None, indicator_options=None,
         indicator_downloads=None, logging=None, indicator_export_filename='all_indicators',
-        ignore_out_of_scope_disaggregation_stats=False):
+        ignore_out_of_scope_disaggregation_stats=False, cache_store=None):
         """Constructor for OutputOpenSdg.
 
         Parameters
@@ -29,6 +29,9 @@ class OutputOpenSdg(OutputBase):
             A filename (without the extension) for the zipped indicator export.
         ignore_out_of_scope_disaggregation_stats : boolean
             Whether to ignore the "not applicable" disaggregation stats.
+        cache_store : dict
+            A store that is passed in to allow caching during the build, to
+            avoid useless duplication.
         """
         if translations is None:
             translations = []
@@ -39,6 +42,7 @@ class OutputOpenSdg(OutputBase):
         self.indicator_downloads = indicator_downloads
         self.indicator_export_filename = indicator_export_filename
         self.ignore_na = ignore_out_of_scope_disaggregation_stats
+        self.cache_store = cache_store
 
 
     def build(self, language=None):
@@ -65,7 +69,11 @@ class OutputOpenSdg(OutputBase):
         for indicator_id in self.get_indicator_ids():
             indicator = self.get_indicator_by_id(indicator_id).language(language)
             # Use the methodology to calculate a progress status.
-            progress_status = IndicatorProgress(indicator, logging=self.logging).get_indicator_status()
+            progress_status = IndicatorProgress(
+                indicator,
+                logging=self.logging,
+                cache_store=self.cache_store,
+            ).get_indicator_status()
             if progress_status:
                 # If the calculations returned something, set it in the indicator's 'meta' property.
                 indicator.meta['progress_status'] = progress_status


### PR DESCRIPTION
@tristanmenard I haven't tested this other than to confirm that it runs the main function one time only. Do you think this might work to avoid the repetitive execution during the translated builds?